### PR TITLE
Switch deployment to local Docker Compose builds

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,91 +1,22 @@
 name: CI/CD DinnerHopping
-on:
-  push:
-    branches: [ main ]
-  workflow_dispatch: {}
-permissions:
-  contents: read
-  packages: write
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
-    environment: VPS_HOST
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Determine lowercase repository owner
-        id: owner
-        run: |
-          echo "lower_owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
-
-      - name: Set up QEMU and Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push backend image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile
-          push: true
-          tags: |
-            ghcr.io/${{ steps.owner.outputs.lower_owner }}/dinnerhopping-backend:latest
-            ghcr.io/${{ steps.owner.outputs.lower_owner }}/dinnerhopping-backend:${{ github.sha }}
-
-      - name: Generate frontend config
-        run: |
-          if [ -f frontend/.env ]; then
-            echo "Generating frontend config from .env..."
-            cd frontend
-            node generate-config.js
-            cd ..
-          else
-            echo "No frontend/.env found, copying from .env.example..."
-            cd frontend
-            echo "BACKEND_BASE=https://dinnerhoppings.acrevon.fr/api/
-              DEBUG_BANNER=falsefrontend/.env" >> .env
-            node generate-config.js
-            cd ..
-          fi
-
-      - name: Upload frontend files as artifact
+  deploy:
         uses: actions/upload-artifact@v4
         with:
           name: frontend-files
-          path: frontend/public/
-
-  deploy:
-    needs: build-and-push
-    runs-on: ubuntu-latest
+      - name: Checkout
+        uses: actions/checkout@v4
     environment: VPS_HOST
     steps:
       - name: Download frontend files artifact
         uses: actions/download-artifact@v4
         with:
           name: frontend-files
-          path: frontend/public/
-
-      - name: Start SSH agent and add key
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
-
-      - name: Rsync frontend to server
-        env:
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      - name: Remote deploy git pull, build images, restart service, healthcheck
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_PORT: ${{ secrets.DEPLOY_SSH_PORT }}
         run: |
           PORT=${DEPLOY_PORT:-22}
-          rsync -az --delete -e "ssh -p ${PORT} -o StrictHostKeyChecking=no" frontend/public/ ${DEPLOY_USER}@${DEPLOY_HOST}:/var/www/dinnerhopping/
-
       - name: Remote deploy git pull, pull image, restart service, healthcheck
         env:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
@@ -107,13 +38,14 @@ jobs:
           fi
           git fetch --all --prune
           git pull --ff-only
-          # If REMOTE_GHCR_PAT/user provided, login to GHCR on the remote host so 'docker-compose pull' can pull private images
-          if [ -n "${REMOTE_GHCR_PAT:-}" ] && [ -n "${REMOTE_GHCR_USER:-}" ]; then
-            echo "${REMOTE_GHCR_PAT}" | sudo docker login ghcr.io -u "${REMOTE_GHCR_USER}" --password-stdin || true
+          if command -v docker-compose >/dev/null 2>&1; then
+            COMPOSE_CMD=(docker-compose)
+          else
+            COMPOSE_CMD=(docker compose)
           fi
-          # Restart service using latest image
           sudo systemctl stop docker-compose-app.service || true
-          sudo docker-compose -f deploy/production-docker-compose.yml pull || true
+          sudo "${COMPOSE_CMD[@]}" -f deploy/production-docker-compose.yml build --pull
+          sudo systemctl daemon-reload || true
           sudo systemctl start docker-compose-app.service
           # Healthcheck
           for i in {1..10}; do

--- a/deploy/docker-compose-app.service
+++ b/deploy/docker-compose-app.service
@@ -1,6 +1,6 @@
 # /etc/systemd/system/docker-compose-app.service
 [Unit]
-Description=DinnerHopping Docker Compose App (backend + mongo)
+Description=DinnerHopping Docker Compose App (frontend + backend + mongo)
 Requires=docker.service
 After=docker.service network-online.target
 
@@ -8,11 +8,11 @@ After=docker.service network-online.target
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=/opt/dinnerhopping/deploy
-# Pull et build (optionnel) puis up
+# Build updated images before starting containers
 ## NOTE: The original version used the Docker CLI plugin syntax `docker compose`.
 ## On this host only the standalone binary `/usr/bin/docker-compose` is installed.
 ## Adjusted accordingly to avoid service start failure (exit code 203 / file not found).
-ExecStartPre=-/usr/bin/docker-compose -f production-docker-compose.yml pull
+ExecStartPre=-/usr/bin/docker-compose -f production-docker-compose.yml build --pull
 ExecStart=/usr/bin/docker-compose -f production-docker-compose.yml up -d
 ExecStop=/usr/bin/docker-compose -f production-docker-compose.yml down
 TimeoutStartSec=0

--- a/deploy/production-docker-compose.yml
+++ b/deploy/production-docker-compose.yml
@@ -10,8 +10,10 @@ services:
     volumes:
       - mongo-data:/data/db
   backend:
-    image: ghcr.io/steeven-1002/dinnerhopping-backend:latest
-    pull_policy: always
+    build:
+      context: ../backend
+      dockerfile: Dockerfile
+    image: dinnerhopping/backend
     restart: unless-stopped
     env_file:
       - ../backend/app/.env
@@ -24,6 +26,16 @@ services:
       - "127.0.0.1:8000:8000"
     volumes:
       - ../backend/logs:/var/log/dinnerhopping
+  frontend:
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile
+    image: dinnerhopping/frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "40332:80"
 volumes:
   mongo-data:
     name: dinnerhopping-mongo-data


### PR DESCRIPTION
Updated CI/CD workflow, systemd service, and Docker Compose config to build frontend and backend images locally instead of pulling from GHCR. Added frontend service to production compose file and revised deployment/rollback documentation to reflect local builds and improved healthcheck instructions.