### PR TITLE
Switch invitation emails to set-password link

### DIFF
--- a/backend/app/email_templates.py
+++ b/backend/app/email_templates.py
@@ -53,9 +53,9 @@ DEFAULT_TEMPLATES = [
     {
         'key': 'invitation',
         'subject': "You've been invited to an event on DinnerHopping",
-        'html_body': '<p>Hi!</p><p>You have been invited to join an event on DinnerHopping. To accept, click: <a href="{{invitation_link}}">Accept invitation</a></p><p>If you don\'t have an account, register with this email.</p><p>— DinnerHopping Team</p>',
+        'html_body': '<p>Hi!</p><p>You have been invited to join an event on DinnerHopping. To accept, click: <a href="{{invitation_link}}">Accept invitation</a></p><p>If you don\'t have an account, register with this email. If an account was created for you, set your password here: <a href="{{set_password_url}}">Set password</a></p><p>— DinnerHopping Team</p>',
         'description': 'Invitation email with accept link',
-        'variables': ['invitation_link','email','temp_password']
+        'variables': ['invitation_link','email','set_password_url']
     },
     {
         'key': 'invitation_accept',

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -164,7 +164,7 @@ async def list_email_templates(_=Depends(require_admin)):
                 'subject': "",
                 'html_body': "",
                 'description': 'Invitation email with accept link',
-                'variables': ['invitation_link','email','temp_password']
+                'variables': ['invitation_link','email','set_password_url']
             },
             {
                 'key': 'invitation_accept',

--- a/backend/app/routers/matching.py
+++ b/backend/app/routers/matching.py
@@ -43,8 +43,19 @@ async def start_matching(event_id: str, payload: dict | None = None, current_adm
     ev = await require_event_published(event_id)
     # enforce registration deadline passed if set
     ddl = ev.get('registration_deadline')
+    deadline_dt = None
+    if ddl:
+        if isinstance(ddl, datetime.datetime):
+            deadline_dt = ddl if ddl.tzinfo is not None else ddl.replace(tzinfo=datetime.timezone.utc)
+        elif isinstance(ddl, str):
+            try:
+                from app import datetime_utils
+                deadline_dt = datetime_utils.parse_iso(ddl)
+            except Exception:
+                # If parsing fails, be conservative and skip the deadline check
+                deadline_dt = None
     now = datetime.datetime.now(datetime.timezone.utc)
-    if ddl and isinstance(ddl, datetime.datetime) and now < ddl:
+    if deadline_dt and now < deadline_dt:
         raise HTTPException(status_code=400, detail='Registration deadline has not passed yet')
     payload = payload or {}
     algorithms: List[str] = payload.get('algorithms') or ['greedy', 'random']

--- a/backend/scripts/seed_email_templates.py
+++ b/backend/scripts/seed_email_templates.py
@@ -28,9 +28,9 @@ DEFAULT_TEMPLATES = [
     {
         'key': 'invitation',
         'subject': 'You\'ve been invited to an event on DinnerHopping',
-        'html_body': '<p>Hi!</p><p>You have been invited to join an event on DinnerHopping. To accept, click: <a href="{{invitation_link}}">Accept invitation</a></p><p>If you don\'t have an account, register with this email.</p><p>— DinnerHopping Team</p>',
+        'html_body': '<p>Hi!</p><p>You have been invited to join an event on DinnerHopping. To accept, click: <a href="{{invitation_link}}">Accept invitation</a></p><p>If you don\'t have an account, register with this email. If an account was created for you, set your password here: <a href="{{set_password_url}}">Set password</a></p><p>— DinnerHopping Team</p>',
         'description': 'Invitation email with accept link',
-        'variables': ['invitation_link','email','temp_password']
+        'variables': ['invitation_link','email','set_password_url']
     },
     {
         'key': 'invitation_accept',


### PR DESCRIPTION
Replaces temporary password handling for invited users with a secure set-password link in both invitation and acceptance flows. Updates email templates, notification logic, and related endpoints to use 'set_password_url' instead of 'temp_password'. Also improves registration payment endpoint URLs and event info enrichment in registration status responses.