### PR TITLE
Add admin chat management features and chat group helpers

### DIFF
--- a/frontend/public/admin-chat-management.html
+++ b/frontend/public/admin-chat-management.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin - Chat Management</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script src="js/config.js"></script>
+  <script src="js/core/client.js"></script>
+  <script src="js/core/auth.js"></script>
+  <script src="js/utils/network-errors.js"></script>
+  <script src="js/debug-banner.js"></script>
+  <script src="js/core/includes.js" defer></script>
+</head>
+<body class="text-[#172a3a] bg-[#f0f4f7] min-h-screen font-inter">
+  <div class="max-w-6xl mx-auto px-4 py-8">
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-2xl font-bold text-[#172a3a]">Chat Management</h1>
+      <div class="flex items-center gap-3">
+        <a href="admin-dashboard.html" class="px-3 py-2 bg-gray-600 text-white rounded-xl">Back to dashboard</a>
+        <a href="admin-email-templates.html" class="px-3 py-2 bg-[#4a5568] text-white rounded-xl">Email Templates</a>
+      </div>
+    </div>
+
+    <div class="bg-white p-4 rounded-2xl shadow border">
+      <div class="flex gap-3 items-center mb-4">
+        <label class="block text-sm font-semibold">Select Event</label>
+        <select id="event-select" class="border rounded p-2"></select>
+        <button id="btn-refresh-events" class="px-3 py-2 bg-[#f46f47] text-white rounded-xl">Refresh</button>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div class="md:col-span-1">
+          <h3 class="font-semibold mb-2">Actions</h3>
+          <div class="space-y-2">
+            <button id="btn-create-chat" class="w-full px-3 py-2 bg-[#008080] text-white rounded-xl">Create Chat for Selected Event</button>
+            <button id="btn-clear-chat" class="w-full px-3 py-2 bg-[#ffc241] text-[#172a3a] rounded-xl">Clear Chats for Event</button>
+            <button id="btn-delete-chat" class="w-full px-3 py-2 bg-[#e53e3e] text-white rounded-xl">Delete Chat Group</button>
+          </div>
+          <div class="mt-4">
+            <label class="block text-sm font-semibold">Manual Group ID (for delete)</label>
+            <input id="manual-group-id" class="mt-1 p-2 border rounded w-full" placeholder="group id">
+          </div>
+        </div>
+
+        <div class="md:col-span-2">
+          <h3 class="font-semibold mb-2">Groups for event</h3>
+          <div id="groups-list" class="space-y-2 bg-gray-50 p-3 rounded max-h-[420px] overflow-auto"></div>
+
+          <div class="mt-4">
+            <h4 class="font-semibold">Post message to group</h4>
+            <div class="flex gap-2 items-center mt-2">
+              <input id="post-group-id" placeholder="group id" class="p-2 border rounded w-1/3">
+              <input id="post-message" placeholder="message body" class="p-2 border rounded flex-1">
+              <button id="btn-post-message" class="px-3 py-2 bg-[#4a5568] text-white rounded-xl">Post</button>
+            </div>
+            <div id="post-status" class="text-sm mt-2"></div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <script src="/js/admin-chat-management.js" defer></script>
+</body>
+</html>

--- a/frontend/public/admin-dashboard.html
+++ b/frontend/public/admin-dashboard.html
@@ -45,7 +45,13 @@
       <div class="flex items-center justify-between mb-4">
         <h2 id="create-form-title" class="text-xl font-bold text-[#f46f47]">Create New Event</h2>
         <div class="flex items-center gap-3">
-          <a href="admin-email-templates.html" class="px-3 py-2 bg-[#4a5568] text-white rounded-xl text-sm hover:opacity-90">Email Templates</a>
+          <div class="relative inline-block text-left">
+            <button id="admin-menu-btn" class="px-3 py-2 bg-[#4a5568] text-white rounded-xl text-sm hover:opacity-90">Admin Menu</button>
+            <div id="admin-menu" class="hidden absolute mt-2 right-0 w-56 bg-white rounded-xl shadow-lg border p-2">
+              <a href="admin-email-templates.html" class="block px-3 py-2 rounded hover:bg-gray-100">Email Templates</a>
+              <a href="admin-chat-management.html" class="block px-3 py-2 rounded hover:bg-gray-100">Chat Management</a>
+            </div>
+          </div>
           <button id="btn-cancel-edit" class="hidden bg-[#4a5568] text-white rounded-xl px-3 py-2 text-sm hover:opacity-90">Cancel edit</button>
         </div>
       </div>

--- a/frontend/public/admin-email-templates.html
+++ b/frontend/public/admin-email-templates.html
@@ -33,6 +33,9 @@
     </div>
 
     <div class="flex gap-6">
+      <div class="w-full flex justify-end mb-4">
+        <a href="admin-dashboard.html" class="px-3 py-2 bg-gray-600 text-white rounded-xl">Back to dashboard</a>
+      </div>
       <div class="w-1/3">
         <button id="newBtn" class="w-full mb-3 py-2 rounded-xl bg-[#f46f47] text-white font-semibold">+ New Template</button>
         <ul id="templateList" class="space-y-2"></ul>

--- a/frontend/public/js/admin-chat-management.js
+++ b/frontend/public/js/admin-chat-management.js
@@ -1,0 +1,176 @@
+// Admin Chat Management
+(async function () {
+  const el = (sel) => document.querySelector(sel);
+  const evSelect = el('#event-select');
+  const btnRefresh = el('#btn-refresh-events');
+  const groupsList = el('#groups-list');
+  const btnCreate = el('#btn-create-chat');
+  const btnClear = el('#btn-clear-chat');
+  const btnDelete = el('#btn-delete-chat');
+  const manualGroupId = el('#manual-group-id');
+  const postGroupId = el('#post-group-id');
+  const postMessage = el('#post-message');
+  const btnPost = el('#btn-post-message');
+  const postStatus = el('#post-status');
+
+  async function apiGet(path) {
+    const r = await window.dh.apiGet(path);
+    if (!r.res.ok) throw new Error('api error');
+    return r.data;
+  }
+
+  async function loadEvents() {
+    evSelect.innerHTML = '';
+    try {
+      const { res, data } = await window.dh.apiGet('/admin/events');
+      if (!res.ok) return;
+      const events = data;
+      events.forEach(ev => {
+        const opt = document.createElement('option');
+        opt.value = ev._id || ev.id || ev.id_str || ev.id;
+        opt.textContent = `${ev.title || ev.name} — ${ev.city || ''} — ${ev.date || ''}`;
+        evSelect.appendChild(opt);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function loadGroupsForSelectedEvent() {
+    groupsList.innerHTML = '';
+    const eventId = evSelect.value;
+    if (!eventId) return;
+    try {
+      // use admin endpoint to list chat groups by event — fallback to /chats/groups?event_id=...
+      const { res, data } = await window.dh.apiGet(`/admin/chats?event_id=${encodeURIComponent(eventId)}`);
+      if (!res.ok) return;
+      const groups = data;
+      if (!groups || groups.length === 0) {
+        groupsList.textContent = 'No groups';
+        return;
+      }
+      groups.forEach(g => {
+        const row = document.createElement('div');
+        row.className = 'p-2 bg-white rounded shadow-sm flex justify-between items-start';
+        const left = document.createElement('div');
+        left.innerHTML = `<div class="font-semibold">ID: ${g._id || g.id}</div><div class="text-sm text-gray-600">section: ${g.section_ref} — participants: ${ (g.participant_emails || []).join(', ') }</div>`;
+        const right = document.createElement('div');
+        right.className = 'flex gap-2';
+        const btnView = document.createElement('button');
+        btnView.textContent = 'View';
+        btnView.className = 'px-2 py-1 bg-[#4a5568] text-white rounded';
+        btnView.addEventListener('click', () => viewGroupMessages(g._id || g.id, g));
+        const btnDel = document.createElement('button');
+        btnDel.textContent = 'Delete';
+        btnDel.className = 'px-2 py-1 bg-red-600 text-white rounded';
+        btnDel.addEventListener('click', () => deleteGroup(g._id || g.id));
+        right.appendChild(btnView);
+        right.appendChild(btnDel);
+        row.appendChild(left);
+        row.appendChild(right);
+        groupsList.appendChild(row);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function viewGroupMessages(groupId, group) {
+    try {
+      const { res: r1, data: g } = await window.dh.apiGet(`/admin/chats/groups/${encodeURIComponent(groupId)}`);
+      if (!r1.ok) return alert('Failed to fetch group');
+      const { res, data: msgs } = await window.dh.apiGet(`/admin/chats/groups/${encodeURIComponent(groupId)}/messages`);
+      let out = `Group ${groupId}\nSection: ${g.section_ref || group.section_ref}\nParticipants: ${(g.participant_emails || group.participant_emails || []).join(', ')}\n\nMessages:\n`;
+      if (res.ok && Array.isArray(msgs)) {
+        msgs.forEach(m => { out += `${m.created_at || ''} — ${m.sender_email || ''}: ${m.body}\n`; });
+      } else {
+        out += 'No messages';
+      }
+      alert(out);
+    } catch (err) {
+      console.error(err);
+      alert('Error fetching messages');
+    }
+  }
+
+  async function createChatForEvent() {
+    const eventId = evSelect.value;
+    if (!eventId) return alert('Select event');
+    try {
+      // call admin endpoint to seed chat groups for that event
+      const { res, data } = await window.dh.apiPost(`/admin/chats/seed?event_id=${encodeURIComponent(eventId)}`, {});
+      if (!res.ok) {
+        alert('Failed to create chats');
+        return;
+      }
+      alert('Created chats');
+      loadGroupsForSelectedEvent();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function clearChatsForEvent() {
+    const eventId = evSelect.value;
+    if (!eventId) return alert('Select event');
+    if (!confirm('Clear (delete) all chat groups for this event?')) return;
+    try {
+      const { res, data } = await window.dh.apiPost(`/admin/chats/clear?event_id=${encodeURIComponent(eventId)}`, {});
+      if (!res.ok) return alert('Failed to clear chats');
+      alert('Cleared chats');
+      loadGroupsForSelectedEvent();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function deleteGroup(groupId) {
+    if (!groupId) groupId = manualGroupId.value;
+    if (!groupId) return alert('No group id');
+    if (!confirm('Delete group ' + groupId + '?')) return;
+    try {
+      const { res } = await window.dh.apiDelete(`/admin/chats/groups/${encodeURIComponent(groupId)}`);
+      if (!res.ok) return alert('Failed to delete');
+      alert('Deleted');
+      loadGroupsForSelectedEvent();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function postMessageToGroup() {
+    const gid = postGroupId.value;
+    const body = postMessage.value;
+    if (!gid || !body) return alert('group id and body required');
+    try {
+      const { res } = await window.dh.apiPost(`/admin/chats/groups/${encodeURIComponent(gid)}/messages`, { body });
+      if (!res.ok) return postStatus.textContent = 'Failed to post';
+      postStatus.textContent = 'Posted as admin';
+      postGroupId.value = '';
+      postMessage.value = '';
+    } catch (err) {
+      console.error(err);
+      postStatus.textContent = 'Error';
+    }
+  }
+
+  btnRefresh.addEventListener('click', loadEvents);
+  evSelect.addEventListener('change', loadGroupsForSelectedEvent);
+  btnCreate.addEventListener('click', createChatForEvent);
+  btnClear.addEventListener('click', clearChatsForEvent);
+  btnDelete.addEventListener('click', () => deleteGroup());
+  btnPost.addEventListener('click', postMessageToGroup);
+
+  // Admin menu toggling on dashboard (used across admin pages) — graceful if not present
+  const adminMenuBtn = document.getElementById('admin-menu-btn');
+  if (adminMenuBtn) {
+    adminMenuBtn.addEventListener('click', () => {
+      const m = document.getElementById('admin-menu');
+      if (!m) return;
+      m.classList.toggle('hidden');
+    });
+  }
+
+  // initial load
+  await loadEvents();
+})();

--- a/frontend/public/js/admin-dashboard.js
+++ b/frontend/public/js/admin-dashboard.js
@@ -79,6 +79,18 @@
     f.chat_enabled.checked = !!ev.chat_enabled;
   }
 
+  // Admin menu toggle (if present on the page)
+  (function bindAdminMenu(){
+    try{
+      const btn = document.getElementById('admin-menu-btn');
+      if (!btn) return;
+      const menu = document.getElementById('admin-menu');
+      if (!menu) return;
+      btn.addEventListener('click', (e)=>{ menu.classList.toggle('hidden'); });
+      document.addEventListener('click', (ev)=>{ if (!btn.contains(ev.target) && !menu.contains(ev.target)){ menu.classList.add('hidden'); } });
+    }catch(e){}
+  })();
+
   function readForm(){
     const f = $('#create-event-form');
     const fd = new FormData(f);

--- a/frontend/public/js/admin-email-templates.js
+++ b/frontend/public/js/admin-email-templates.js
@@ -170,7 +170,7 @@
   fields.vars.addEventListener('input', renderVariables);
   document.getElementById('saveBtn').onclick = save;
   document.getElementById('deleteBtn').onclick = del;
-  document.getElementById('cancelBtn').onclick = () => { editor.style.display='none'; };
+  document.getElementById('cancelBtn').onclick = () => { window.location.href = 'admin-dashboard.html'; };
 
   loadList();
 })();


### PR DESCRIPTION
Introduces admin endpoints for chat group management, including listing, seeding, clearing, deleting, and posting messages to chat groups. Adds best-effort chat group creation during event updates and registrations, and implements cleanup utilities for old chat groups. Updates frontend with a new admin chat management page, integrates admin menu navigation, and enhances related admin dashboard and email template pages.