### PR TITLE
Improve invitation filtering and fix event link URLs

### DIFF
--- a/frontend/public/js/pages/payment-success.js
+++ b/frontend/public/js/pages/payment-success.js
@@ -103,8 +103,8 @@
         const data = await res.json();
         const latest = Array.isArray(data) && data.length ? data[0] : null;
         if(latest && latest.id && goDashboard){
-          goDashboard.href = `/event?id=${encodeURIComponent(latest.id)}`;
-          if(!target) target = `/event?id=${encodeURIComponent(latest.id)}`;
+          goDashboard.href = `/event.html?id=${encodeURIComponent(latest.id)}`;
+          if(!target) target = `/event.html?id=${encodeURIComponent(latest.id)}`;
         }
       }
     }catch{}


### PR DESCRIPTION
Enhanced backend invitation listing to enforce owner/admin checks when filtering by registration_id. On the frontend, added stricter filtering to only show invitations relevant to the current user and updated event links to use '/event.html' instead of '/event'.